### PR TITLE
Update NB_USER to be a valid unix username

### DIFF
--- a/jupyterhub_chameleon/authenticator/keycloak.py
+++ b/jupyterhub_chameleon/authenticator/keycloak.py
@@ -253,7 +253,7 @@ class ChameleonKeycloakAuthenticator(OAuthenticator):
             return None
 
         user_json = json.loads(user_resp.body.decode("utf8", "replace"))
-        username = user_json.get("preferred_username").split("@", 1)[0]
+        username = user_json.get("preferred_username")
         is_admin = self.keycloak_admin_group in user_json.get(
             self.keycloak_groups_claim, []
         )
@@ -284,7 +284,6 @@ class ChameleonKeycloakAuthenticator(OAuthenticator):
                 )
             )
             openstack_rc = None
-
         return {
             "name": username,
             "admin": is_admin,

--- a/jupyterhub_chameleon/spawner.py
+++ b/jupyterhub_chameleon/spawner.py
@@ -1,4 +1,5 @@
 import os
+import re
 
 from dockerspawner import DockerSpawner
 from traitlets import default, Bool, Dict, Unicode
@@ -78,7 +79,6 @@ class ChameleonSpawner(DockerSpawner):
                 vols[self._default_name_template] = self._gen_volume_config(
                     self.work_dir
                 )
-
         vols.update(self.extra_volumes)
         return vols
 
@@ -139,12 +139,22 @@ class ChameleonSpawner(DockerSpawner):
     def _network_name(self):
         return os.environ["DOCKER_NETWORK_NAME"]
 
+    def _get_unix_user(self):
+        name = self.user.name
+        # Escape bad characters (just make them unix_safe)
+        name = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+        # Ensure we start with an proper character
+        if not re.search(r"^[a-z_]", name):
+            name = "_" + name
+        # Usernames may only be 32 characters
+        return name[:32]
+
     def get_env(self):
         env = super().get_env()
 
         extra_env = {}
         # Rename notebook user (jovyan) to Chameleon username
-        extra_env["NB_USER"] = self.user.name
+        extra_env["NB_USER"] = self._get_unix_user()
         # ssh_dir = self.share_dir if self.name else self.work_dir
         ssh_dir = self.work_dir
         extra_env["OS_KEYPAIR_PRIVATE_KEY"] = f"{ssh_dir}/.ssh/id_rsa"

--- a/jupyterhub_chameleon/spawner.py
+++ b/jupyterhub_chameleon/spawner.py
@@ -140,9 +140,9 @@ class ChameleonSpawner(DockerSpawner):
         return os.environ["DOCKER_NETWORK_NAME"]
 
     def _get_unix_user(self):
-        name = self.user.name
+        name = self.user.name.lower()
         # Escape bad characters (just make them unix_safe)
-        name = re.sub(r"[^a-zA-Z0-9_-]", "_", name)
+        name = re.sub(r"[^a-z0-9_-]", "_", name)
         # Ensure we start with an proper character
         if not re.search(r"^[a-z_]", name):
             name = "_" + name


### PR DESCRIPTION
Per the useradd man page, a username is modified

```
       It is usually recommended to only use usernames that begin
       with a lower case letter or an underscore, followed by lower
       case letters, digits, underscores, or dashes. They can end
       with a dollar sign. In regular expression terms:
       [a-z_][a-z0-9_-]*[$]?

       On Debian, the only constraints are that usernames must
       neither start with a dash ('-') nor plus ('+') nor tilde ('~')
       nor contain a colon (':'), a comma (','), or a whitespace
       (space: ' ', end of line: '\n', tabulation: '\t', etc.). Note
       that using a slash ('/') may break the default algorithm for
       the definition of the user's home directory.

       Usernames may only be up to 32 characters long.

```