### PR TITLE
Fix trovi content download

### DIFF
--- a/jupyterhub_chameleon/spawner.py
+++ b/jupyterhub_chameleon/spawner.py
@@ -181,14 +181,13 @@ class ChameleonSpawner(DockerSpawner):
         # Add parameters for experiment import
         artifact = self.get_artifact()
         if artifact:
-            deposition_url = artifact.deposition_url()
-            extra_env["ARTIFACT_DEPOSITION_URL"] = deposition_url
+            extra_env["ARTIFACT_CONTENTS_URL"] = artifact.contents_url
             extra_env["ARTIFACT_DEPOSITION_REPO"] = artifact.deposition_repo
             extra_env["ARTIFACT_ID"] = artifact.id
             extra_env["ARTIFACT_OWNERSHIP"] = artifact.ownership
             self.log.info(
                 f"User {self.user.name} importing from "
-                f"{artifact.deposition_repo}: {deposition_url}"
+                f"{artifact.deposition_repo}: {artifact.contents_url}"
             )
 
         env.update(extra_env)

--- a/jupyterhub_chameleon/utils.py
+++ b/jupyterhub_chameleon/utils.py
@@ -27,10 +27,11 @@ class Artifact:
             environment is torn down. Default = False.
     """
     def __init__(self, deposition_repo=None, deposition_id=None, id=None,
-                 ownership='fork', ephemeral=None):
+                 contents_url=None, ownership='fork', ephemeral=None):
         self.id = id
         self.deposition_repo = deposition_repo
         self.deposition_id = deposition_id
+        self.contents_url = contents_url
         self.ownership = ownership
         self.ephemeral = ephemeral in [True, 'True', 'true', 'yes', '1']
 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="jupyterhub-chameleon",
-    version="2.0.1",
+    version="2.0.2",
     description="Chameleon extensions for JupyterHub",
     url="https://github.com/chameleoncloud/jupyterhub-chameleon",
     author="Jason Anderson",


### PR DESCRIPTION
JupyterHub now expects a content URL from Portal, which it injests and stores on an `Artifact` object. This URL is then curled by JupyterLab when the notebook spawns
