### PR TITLE
Cleanup artifact contents info passing

### DIFF
--- a/jupyterhub_chameleon/handler.py
+++ b/jupyterhub_chameleon/handler.py
@@ -18,7 +18,7 @@ from tornado.httpclient import (
 from tornado.curl_httpclient import CurlError
 
 from .authenticator.config import OPENSTACK_RC_AUTH_STATE_KEY
-from .utils import Artifact, upload_url
+from .utils import Artifact
 
 
 class UserRedirectExperimentHandler(BaseHandler):
@@ -42,8 +42,8 @@ class UserRedirectExperimentHandler(BaseHandler):
                 raise HTTPError(400, ("Could not understand import request"))
 
             sha = hashlib.sha256()
-            sha.update(artifact.deposition_repo.encode("utf-8"))
-            sha.update(artifact.deposition_id.encode("utf-8"))
+            sha.update(artifact.contents_repo.encode("utf-8"))
+            sha.update(artifact.contents_id.encode("utf-8"))
             server_name = sha.hexdigest()[:7]
 
             # Auto-open file when we land in server

--- a/jupyterhub_chameleon/spawner.py
+++ b/jupyterhub_chameleon/spawner.py
@@ -183,12 +183,12 @@ class ChameleonSpawner(DockerSpawner):
         if artifact:
             extra_env["ARTIFACT_CONTENTS_URL"] = artifact.contents_url
             extra_env["ARTIFACT_CONTENTS_PROTO"] = artifact.contents_proto
-            extra_env["ARTIFACT_DEPOSITION_REPO"] = artifact.deposition_repo
-            extra_env["ARTIFACT_ID"] = artifact.id
+            extra_env["ARTIFACT_CONTENTS_ID"] = artifact.contents_id
+            extra_env["ARTIFACT_CONTENTS_REPO"] = artifact.contents_repo
             extra_env["ARTIFACT_OWNERSHIP"] = artifact.ownership
             self.log.info(
                 f"User {self.user.name} importing from "
-                f"{artifact.deposition_repo}: {artifact.contents_url}"
+                f"{artifact.contents_repo}: {artifact.contents_url}"
             )
 
         env.update(extra_env)

--- a/jupyterhub_chameleon/utils.py
+++ b/jupyterhub_chameleon/utils.py
@@ -1,10 +1,6 @@
 import argparse
-import hashlib
-import hmac
 import os
-import requests
-from time import time
-from urllib.parse import parse_qsl, urljoin
+from urllib.parse import parse_qsl
 
 from keystoneauth1 import loading
 from keystoneauth1.session import Session
@@ -14,11 +10,10 @@ class Artifact:
     """A shared experiment/research artifact that can be spawned in JupyterHub.
 
     Attrs:
-        deposition_repo (str): the name of the deposition repository (e.g.,
-            "zenodo" or "chameleon")
-        deposition_id (str): the ID of the deposition within the repository.
-        id (str): the external Trovi ID of the artifact linked to this
-            deposition. Default = None.
+        contents_id (str): the ID of the artifact's Trovi contents.
+        contents_repo (str): the name of the artifact's Trovi contents repository.
+        contents_url (str): the access URL for the artifact's Trovi contents.
+        contents_proto (str): the protocol for accessing the artifact's Trovi contents.
         ownership (str): the requesting user's ownership status of this
             artifact. Default = "fork".
         ephemeral (bool): whether the artifact's working environment should
@@ -26,28 +21,27 @@ class Artifact:
             from the working directory should be saved when the spawned
             environment is torn down. Default = False.
     """
-    def __init__(self, deposition_repo=None, deposition_id=None, id=None,
-                 contents_url=None, ownership='fork', ephemeral=None,
-                 contents_proto=None):
-        self.id = id
-        self.deposition_repo = deposition_repo
-        self.deposition_id = deposition_id
+
+    def __init__(
+        self,
+        contents_id=None,
+        contents_repo=None,
+        contents_url=None,
+        contents_proto=None,
+        ownership="fork",
+        ephemeral=None,
+    ):
+        self.contents_id = contents_id
+        self.contents_repo = contents_repo
         self.contents_url = contents_url
         self.contents_proto = contents_proto
         self.ownership = ownership
-        self.ephemeral = ephemeral in [True, 'True', 'true', 'yes', '1']
+        self.ephemeral = ephemeral in [True, "True", "true", "yes", "1"]
 
-        # Only the deposition information is required. Theoretically this can
-        # allow importing arbitrary Zenodo DOIs or from other sources that are
-        # not yet existing on Trovi.
-        if not (deposition_repo and deposition_id):
-            raise ValueError('Missing deposition information')
-
-    def deposition_url(self):
-        url_factory = getattr(self.__class__, f'{self.deposition_repo}_url_factory', None)
-        if not url_factory:
-            return None
-        return url_factory(self.deposition_id)
+        # Only the contents information is required. Theoretically this can
+        # allow importing from other sources that are not yet existing on Trovi.
+        if not (contents_repo and contents_id):
+            raise ValueError("Missing contents information")
 
     @classmethod
     def from_query(cls, query):
@@ -58,40 +52,6 @@ class Artifact:
             return cls(**query)
         except Exception:
             return None
-
-    @staticmethod
-    def chameleon_url_factory(deposition_id: str) -> str:
-        origin, path = _swift_url_parts(deposition_id)
-        key = os.environ['ARTIFACT_SHARING_SWIFT_TEMP_URL_KEY']
-        duration_in_seconds = 60
-        expires = int(time() + duration_in_seconds)
-        hmac_body = f'GET\n{expires}\n{path}'
-        sig = hmac.new(
-            key.encode('utf-8'), hmac_body.encode('utf-8'),
-            hashlib.sha1
-        ).hexdigest()
-
-        return f'{origin}{path}?temp_url_sig={sig}&temp_url_expires={expires}'
-
-    @staticmethod
-    def http_url_factory(deposition_id: str) -> str:
-        return deposition_id
-
-    @staticmethod
-    def zenodo_url_factory(deposition_id: str) -> str:
-        # TODO: make this configurable
-        zenodo_base = 'https://zenodo.org'
-        record_id = deposition_id.split('.')[-1]
-        res = requests.get(f'{zenodo_base}/api/records/{record_id}')
-        res.raise_for_status()
-        file_links = [
-            f.get('links', {}).get('self')
-            for f in res.json().get('files', [])
-        ]
-        file_links = [l for l in file_links if l is not None]
-        if not file_links:
-            raise ValueError('Found no file URLs on Zenodo deposition')
-        return file_links[0]
 
 
 def keystone_session(env_overrides: dict = {}) -> Session:
@@ -115,11 +75,10 @@ def keystone_session(env_overrides: dict = {}) -> Session:
         for key, value in env_overrides.items()
         # NOTE(jason): we ignore some environment variables, as they are not
         # supported as KSA command-line args.
-        if key not in ['OS_IDENTITY_API_VERSION']
+        if key not in ["OS_IDENTITY_API_VERSION"]
     ]
     parser = argparse.ArgumentParser()
-    loading.cli.register_argparse_arguments(
-        parser, fake_argv, default='token')
+    loading.cli.register_argparse_arguments(parser, fake_argv, default="token")
     loading.session.register_argparse_arguments(parser)
     loading.adapter.register_argparse_arguments(parser)
     args = parser.parse_args(fake_argv)
@@ -129,36 +88,8 @@ def keystone_session(env_overrides: dict = {}) -> Session:
 
 def artifact_sharing_keystone_session():
     artifact_sharing_overrides = {
-        key.replace('ARTIFACT_SHARING_', ''): value
+        key.replace("ARTIFACT_SHARING_", ""): value
         for key, value in os.environ.items()
-        if key.startswith('ARTIFACT_SHARING_OS_')
+        if key.startswith("ARTIFACT_SHARING_OS_")
     }
     return keystone_session(env_overrides=artifact_sharing_overrides)
-
-
-def _swift_url_parts(deposition_id: str) -> 'tuple[str,str]':
-    session = artifact_sharing_keystone_session()
-    project_id = os.environ.get(
-        'ARTIFACT_SHARING_SWIFT_ACCOUNT', session.get_project_id())
-    endpoint = session.get_endpoint(
-        service_type='object-store',
-        interface=os.environ.get('ARTIFACT_SHARING_OS_INTERFACE',
-            os.environ.get('OS_INTERFACE', 'public')),
-        region_name=os.environ.get('ARTIFACT_SHARING_OS_REGION_NAME',
-            os.environ.get('OS_REGION_NAME')))
-
-    if not endpoint:
-        raise ValueError('Could not discover object-store endpoint')
-
-    origin = endpoint[:endpoint.index('/v1/')]
-    container = os.environ.get('ARTIFACT_SHARING_SWIFT_CONTAINER', 'trovi')
-    return origin, f'/v1/AUTH_{project_id}/{container}/{deposition_id}'
-
-
-def upload_url(trovi_token: dict) -> str:
-    return urljoin(
-        os.getenv("TROVI_URL"),
-        "/contents/"
-        "?backend=chameleon"
-        f"&access_token={trovi_token['access_token']}"
-    )


### PR DESCRIPTION
This cleans up a lot of the passing of artifact state from the hub
to the individual notebook server env. Notably it removes a lot of
the use of 'deposition' as a word and also removes dead code that
now lives in Trovi, since we are through the migration.