### PR TITLE
Set `OS_PROJECT_NAME` in jupyter environment

### DIFF
--- a/jupyterhub_chameleon/authenticator/keycloak.py
+++ b/jupyterhub_chameleon/authenticator/keycloak.py
@@ -269,7 +269,8 @@ class ChameleonKeycloakAuthenticator(OAuthenticator):
             self.keycloak_groups_claim, []
         )
 
-        has_active_allocations = len(user_json.get("projects", [])) > 0
+        user_projects = user_json.get("projects", [])
+        has_active_allocations = len(user_projects) > 0
         if not has_active_allocations:
             self.log.info(f"User {username} does not have any active allocations")
             return None
@@ -287,6 +288,8 @@ class ChameleonKeycloakAuthenticator(OAuthenticator):
             }
             if self.keystone_default_region_name:
                 openstack_rc["OS_REGION_NAME"] = self.keystone_default_region_name
+            if user_projects:
+                openstack_rc["OS_PROJECT_NAME"] = user_projects[0]["id"]
         else:
             self.log.warning(
                 (

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="jupyterhub-chameleon",
-    version="2.0.6",
+    version="2.0.7",
     description="Chameleon extensions for JupyterHub",
     url="https://github.com/chameleoncloud/jupyterhub-chameleon",
     author="Jason Anderson",


### PR DESCRIPTION
Selects the first project name and sets it in the user's Jupyter environment. If the user wants to change this, they can override it manually. The jupyter environment is cookied, so this change may not propagate immediately even if the user creates a new container.
