### PR TITLE
Fix volume and pod name length

### DIFF
--- a/jupyterhub_chameleon/authenticator/openstack_oauth.py
+++ b/jupyterhub_chameleon/authenticator/openstack_oauth.py
@@ -243,7 +243,6 @@ class OpenstackOAuthenticator(GenericOAuthenticator):
             return
 
         openrc_vars = auth_state.get(OPENSTACK_RC_AUTH_STATE_KEY, {})
-        self.log.info(openrc_vars)
         for rc_key, rc_value in openrc_vars.items():
             spawner.environment[rc_key] = rc_value
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # ChameleonCloud-provided
-jupyterhub-chameleon==2.0.17
+jupyterhub-chameleon==2.0.18
 kubernetes==25.3.0
 PyJWT==2.4.0
 escapism==1.0.1

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="jupyterhub-chameleon",
-    version="2.0.17",
+    version="2.0.18",
     description="Chameleon extensions for JupyterHub",
     url="https://github.com/chameleoncloud/jupyterhub-chameleon",
     author="Jason Anderson",


### PR DESCRIPTION
The pre_spawn_hook is called before the pod object is created in kubernetes. We use this to overwrite the templates used to generate the pod name, and the volume name, as these are limited to 63 characters. Note the claim name in the volume is what is actually used to map data into the container, so this does not affect user data. In fact, I'm 99% sure the volume name can be static (no templating) since it is under the pod, which has a unique name, but I'm assuming there might be some reason jupyterhub has it include the username.