### PR TITLE
Bump hub to 3.2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG base_image=jupyterhub/k8s-hub:2.0.0
+ARG base_image=jupyterhub/k8s-hub:3.2.0
 
 FROM $base_image as base
 


### PR DESCRIPTION
This is part of upgrading the helm chart to 3.2.0 in jupyterhub-kubernates
PR - https://github.com/ChameleonCloud/jupyterhub-kubernetes/pull/2